### PR TITLE
Add telegram user ID to orders

### DIFF
--- a/components/cart/actions.ts
+++ b/components/cart/actions.ts
@@ -98,7 +98,7 @@ export const checkoutCart = async (input: DraftOrderInput, draftOrderId: string)
     const draftOrder = await getDraftOrder(draftOrderId);
 
     const { reserveInventoryUntil, customAttributes } = draftOrder;
-    const { lineItems: newLineItems, poNumber } = input;
+    const { lineItems: newLineItems, poNumber, note } = input;
 
     if (isReserveValid(reserveInventoryUntil)) {
       //Update draft order content – just in case if user added new goods in cart
@@ -120,6 +120,7 @@ export const checkoutCart = async (input: DraftOrderInput, draftOrderId: string)
       const newInput: DraftOrderInput = {
         ...input,
         poNumber,
+        note,
         lineItems: filteredNewLineItems,
         customAttributes: updatedCustomAttributes
       };

--- a/components/cart/cart.tsx
+++ b/components/cart/cart.tsx
@@ -67,6 +67,7 @@ export const CartPage: FunctionComponent<Props> = ({ locations }) => {
         lineItems,
         reserveInventoryUntil: createReserveTimestamp(30),
         customAttributes,
+        note: user?.id,
         poNumber: address // This is workaround: we set wallet's address as Post Office Number as this data is shared among Draft Order Update Input, Draft Order and Order and can be used to fetch them
       };
 

--- a/lib/shopify/admin/types.ts
+++ b/lib/shopify/admin/types.ts
@@ -16,6 +16,7 @@ export type DraftOrderInput = {
   phone?: string;
   reserveInventoryUntil?: string;
   poNumber?: string;
+  note?: number;
 };
 
 export type LineItem = {


### PR DESCRIPTION
Added ability to send Telegram user ID to Shopify order. 
This functionality is needed for correct webhook work.